### PR TITLE
refactoring

### DIFF
--- a/src/modules/Game.ts
+++ b/src/modules/Game.ts
@@ -56,7 +56,7 @@ const companyOutputList = companyOutputData.companyOutputs
 const userRepository = AppDataSource.getRepository(UserEntity)
 
 export const registerOnly = createCheckDecorator(
-  async (client: CommandClient, i: Interaction | Message) => {
+  async (_: CommandClient, i: Interaction | Message) => {
     let koiUser: User
     if (i instanceof BaseInteraction)
       if (i.isChatInputCommand()) koiUser = i.user

--- a/src/modules/Game.ts
+++ b/src/modules/Game.ts
@@ -1,7 +1,6 @@
 import { UserEntity } from '../entities/UserEntity'
 import { AppDataSource } from '../index'
 import {
-  CommandClient,
   Extension,
   applicationCommand,
   createCheckDecorator,
@@ -56,7 +55,7 @@ const companyOutputList = companyOutputData.companyOutputs
 const userRepository = AppDataSource.getRepository(UserEntity)
 
 export const registerOnly = createCheckDecorator(
-  async (_: CommandClient, i: Interaction | Message) => {
+  async (_, i: Interaction | Message) => {
     let koiUser: User
     if (i instanceof BaseInteraction)
       if (i.isChatInputCommand()) koiUser = i.user

--- a/src/modules/Game.ts
+++ b/src/modules/Game.ts
@@ -213,6 +213,7 @@ class GameExtension extends Extension {
   ) {
     await i.deferReply()
 
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const nowUser = (await userRepository.findOneBy({
       id: i.user.id,
     }))!

--- a/src/modules/Novel.ts
+++ b/src/modules/Novel.ts
@@ -1,16 +1,10 @@
-import {
-  Extension,
-  applicationCommand,
-  listener,
-  option,
-} from '@pikokr/command.ts'
+import { Extension, applicationCommand, option } from '@pikokr/command.ts'
 import axios from 'axios'
 import {
   ApplicationCommandOptionType,
   ApplicationCommandType,
   ChatInputCommandInteraction,
   EmbedBuilder,
-  Message,
 } from 'discord.js'
 
 interface AuthorItem {

--- a/src/utils/korean.ts
+++ b/src/utils/korean.ts
@@ -5,7 +5,7 @@
  * @param yes 주어진 단어가 받침이 있을 때 이어질 문자열
  * @param no 주어진 단어가 받침이 없을 때 이어질 문자열
  */
-export function end_check(word: string, yes = '', no = ''): string {
+export const end_check = (word: string, yes = '', no = '') => {
   let molu = `(${yes}/${no})`
   if (yes.length == 0) molu = `(${no})`
   if (no.length == 0) molu = `(${yes})`


### PR DESCRIPTION
- function을 만들기 위해 `function` keyword를 사용하는 대신 ES6의 arrow function (`() => {}`)을 사용
- unused parameter의 이름을 `_` (underscore)로 변경하고 type annotation을 삭제
- unused imports 삭제
- non-null assertion (`value!`)를 불가피하게 사용해야 하는 경우 eslint warning이 발생하지 않게 `// eslint-disable-next-line @typescript-eslint/no-non-null-assertion` comment를 추가